### PR TITLE
Fix chapter url

### DIFF
--- a/filter/CrossrefXmlFilter.php
+++ b/filter/CrossrefXmlFilter.php
@@ -392,7 +392,7 @@ class CrossrefXmlFilter extends NativeExportFilter
             $context->getPath(),
             'catalog',
             'book',
-            $chapter->isPageEnabled() === 1
+            $chapter->isPageEnabled() == 1
                 ? [$submission->getBestId(), 'chapter', $chapter->getId()]
                 : [$submission->getBestId()],
             null,


### PR DESCRIPTION
Fixes the URL resource for chapters that have their own landing page.

Previously, the plugin was always sending the book-level URL for all chapters, even when individual chapter pages were enabled.

This was due to the condition chapter->isPageEnabled() === 1 not working as expected, since isPageEnabled() can return a string instead of an integer