### PR TITLE
Feature filter collection

### DIFF
--- a/filter/CrossrefXmlFilter.php
+++ b/filter/CrossrefXmlFilter.php
@@ -286,7 +286,7 @@ class CrossrefXmlFilter extends NativeExportFilter
             return $format->getIsAvailable() && 
             $format->getIsApproved();
         });
-        $this->appendTextMiningCollectionNodes($doc, $doiDataNode, $submission, $validFormats);    
+        $this->appendTextMiningCollectionNodes($doc, $doiDataNode, $submission, $validFormats, true);    
 		$bookMetadataNode->appendChild($doiDataNode);
 
 		return $bookMetadataNode;
@@ -300,7 +300,7 @@ class CrossrefXmlFilter extends NativeExportFilter
      * @param \APP\submission\Submission $submission
      * @param array $publicationFormats Array of \PKP\publicationFormats\PublicationFormat objects
      */
-    public function appendTextMiningCollectionNodes($doc, $doiDataNode, $submission, $validFormats)
+    public function appendTextMiningCollectionNodes($doc, $doiDataNode, $submission, $validFormats, $onlyMonographFiles = true)
     {
         try {
             $deployment = $this->getDeployment();
@@ -308,20 +308,27 @@ class CrossrefXmlFilter extends NativeExportFilter
             $request = Application::get()->getRequest();
             $dispatcher = $this->_getDispatcher($request);
     
-            // Obtener todos los archivos de prueba (proof) visibles
+            // Get all visible proof files
             $submissionFiles = Repo::submissionFile()
                 ->getCollector()
                 ->filterBySubmissionIds([$submission->getId()])
                 ->filterByFileStages([SubmissionFile::SUBMISSION_FILE_PROOF])
                 ->getMany()
                 ->filter(fn($file) => $file->getViewable());
-    
-            $monographFiles = $submissionFiles->filter(function ($file) {
-                return $file->getData('genreId') == 3;
-            });
+
+            $monographFileGenreIds = [3]; // ID for book manuscript
+            $chapterFileGenreIds = [4]; // ID for chapter manuscript
+                
+            $filteredFiles = $submissionFiles->filter(function ($file) use ($onlyMonographFiles, $monographFileGenreIds, $chapterFileGenreIds) {
+                $genreId = $file->getData('genreId');
+                return $file->getData('viewable') === true &&
+                       ($onlyMonographFiles
+                            ? in_array($genreId, $monographFileGenreIds)
+                            : in_array($genreId, $chapterFileGenreIds));
+            });            
     
             $filesByFormatId = [];
-            foreach ($monographFiles as $file) {
+            foreach ($filteredFiles as $file) {
                 $formatId = $file->getData('assocId');
                 if (!isset($filesByFormatId[$formatId])) {
                     $filesByFormatId[$formatId] = [];
@@ -368,8 +375,6 @@ class CrossrefXmlFilter extends NativeExportFilter
             error_log('Error in appendTextMiningCollectionNodes: ' . $e->getMessage());
         }
     }
-    
-      
 
     /**
      * Create and return the Crossref book series metadata node 'series_metadata'.
@@ -489,6 +494,13 @@ class CrossrefXmlFilter extends NativeExportFilter
         $doiDataNode = $doc->createElementNS($deployment->getNamespace(), "doi_data");
 		$doiDataNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'doi', $this->xmlEscape($doi)));
 		$doiDataNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'resource', $this->xmlEscape($url)));
+        // Publication formats
+        $publicationFormats = $publication->getData('publicationFormats');
+        $validFormats = array_filter($publicationFormats, function($format) {
+            return $format->getIsAvailable() && 
+            $format->getIsApproved();
+        });
+        $this->appendTextMiningCollectionNodes($doc, $doiDataNode, $submission, $validFormats, false); 
 		$contentItemNode->appendChild($doiDataNode);
 
 		return $contentItemNode;

--- a/filter/CrossrefXmlFilter.php
+++ b/filter/CrossrefXmlFilter.php
@@ -30,7 +30,7 @@ use PKP\core\PKPString;
 use PKP\filter\FilterGroup;
 use PKP\i18n\LocaleConversion;
 use PKP\plugins\importexport\native\filter\NativeExportFilter;
-use APP\file\SubmissionFile;
+use PKP\submissionFile\SubmissionFile;
 
 class CrossrefXmlFilter extends NativeExportFilter
 {
@@ -286,8 +286,7 @@ class CrossrefXmlFilter extends NativeExportFilter
             return $format->getIsAvailable() && 
             $format->getIsApproved();
         });
-        error_log(print_r($validFormats, true));
-        $this->appendTextMiningCollectionNodes($doc, $doiDataNode, $submission, $validFormats);
+        $this->appendTextMiningCollectionNodes($doc, $doiDataNode, $submission, $validFormats);    
 		$bookMetadataNode->appendChild($doiDataNode);
 
 		return $bookMetadataNode;
@@ -301,56 +300,76 @@ class CrossrefXmlFilter extends NativeExportFilter
      * @param \APP\submission\Submission $submission
      * @param array $publicationFormats Array of \PKP\publicationFormats\PublicationFormat objects
      */
-    public function appendTextMiningCollectionNodes($doc, $doiDataNode, $submission, $publicationFormats)
+    public function appendTextMiningCollectionNodes($doc, $doiDataNode, $submission, $validFormats)
     {
-        $deployment = $this->getDeployment();
-        $context = $deployment->getContext();
-        $request = Application::get()->getRequest();
-        $dispatcher = $this->_getDispatcher($request);
+        try {
+            $deployment = $this->getDeployment();
+            $context = $deployment->getContext();
+            $request = Application::get()->getRequest();
+            $dispatcher = $this->_getDispatcher($request);
     
-        $textMiningCollectionNode = $doc->createElementNS($deployment->getNamespace(), 'collection');
-        $textMiningCollectionNode->setAttribute('property', 'text-mining');
+            // Obtener todos los archivos de prueba (proof) visibles
+            $submissionFiles = Repo::submissionFile()
+                ->getCollector()
+                ->filterBySubmissionIds([$submission->getId()])
+                ->filterByFileStages([SubmissionFile::SUBMISSION_FILE_PROOF])
+                ->getMany()
+                ->filter(fn($file) => $file->getViewable());
     
-        // Obtener todos los archivos de prueba asociados a la monografía
-        $submissionFiles = Services::get('submissionFile')->getMany([
-            'submissionIds' => [$submission->getId()],
-            'fileStages' => [SubmissionFile::SUBMISSION_FILE_PROOF],
-        ]);
-    
-        foreach ($publicationFormats as $publicationFormat) {
-            $formatId = $publicationFormat->getId();
-    
-            // Filtrar archivos relacionados con este formato
-            $formatFiles = array_filter($submissionFiles, function($file) use ($formatId) {
-                return $file->getAssocType() === ASSOC_TYPE_PUBLICATION_FORMAT &&
-                       $file->getAssocId() === $formatId;
+            $monographFiles = $submissionFiles->filter(function ($file) {
+                return $file->getData('genreId') == 3;
             });
     
-            foreach ($formatFiles as $file) {
-                // Construir URL personalizada: /catalog/view/{submission_id}/{pub_format_id}/{file_id}
-                $resourceUrl = $dispatcher->url(
-                    $request,
-                    PKPApplication::ROUTE_PAGE,
-                    $context->getPath(),
-                    'catalog',
-                    'view',
-                    [$submission->getId(), $formatId, $file->getFileId()],
-                    null,
-                    null,
-                    true
-                );
-    
-                $itemNode = $doc->createElementNS($deployment->getNamespace(), 'item');
-                $resourceNode = $doc->createElementNS($deployment->getNamespace(), 'resource', $resourceUrl);
-                $resourceNode->setAttribute('mime_type', $file->getData('mimetype'));
-    
-                $itemNode->appendChild($resourceNode);
-                $textMiningCollectionNode->appendChild($itemNode);
+            $filesByFormatId = [];
+            foreach ($monographFiles as $file) {
+                $formatId = $file->getData('assocId');
+                if (!isset($filesByFormatId[$formatId])) {
+                    $filesByFormatId[$formatId] = [];
+                }
+                $filesByFormatId[$formatId][] = $file;
             }
-        }
     
-        $doiDataNode->appendChild($textMiningCollectionNode);
-    }    
+            $textMiningCollectionNode = $doc->createElementNS($deployment->getNamespace(), 'collection');
+            $textMiningCollectionNode->setAttribute('property', 'text-mining');
+    
+            foreach ($validFormats as $format) {
+                $formatId = $format->getId();
+                if (empty($filesByFormatId[$formatId])) {
+                    continue;
+                }
+    
+                foreach ($filesByFormatId[$formatId] as $file) {
+                    $url = $dispatcher->url(
+                        $request,
+                        PKPApplication::ROUTE_PAGE,
+                        $context->getPath(),
+                        'catalog',
+                        'view',
+                        [$submission->getId(), $formatId, $file->getId()],
+                        null,
+                        null,
+                        true
+                    );
+    
+                    $itemNode = $doc->createElementNS($deployment->getNamespace(), 'item');
+                    $resourceNode = $doc->createElementNS($deployment->getNamespace(), 'resource', $url);
+    
+                    if ($file->getData('mimetype')) {
+                        $resourceNode->setAttribute('mime_type', $file->getData('mimetype'));
+                    }
+    
+                    $itemNode->appendChild($resourceNode);
+                    $textMiningCollectionNode->appendChild($itemNode);
+                }
+            }
+    
+            $doiDataNode->appendChild($textMiningCollectionNode);
+        } catch (Throwable $e) {
+            error_log('Error in appendTextMiningCollectionNodes: ' . $e->getMessage());
+        }
+    }
+    
+      
 
     /**
      * Create and return the Crossref book series metadata node 'series_metadata'.

--- a/filter/CrossrefXmlFilter.php
+++ b/filter/CrossrefXmlFilter.php
@@ -281,26 +281,147 @@ class CrossrefXmlFilter extends NativeExportFilter
 		$doiDataNode = $doc->createElementNS($deployment->getNamespace(), "doi_data");
 		$doiDataNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'doi', $this->xmlEscape($doi)));
 		$doiDataNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'resource', $this->xmlEscape($url)));
+
         // Publication formats
         $validFormats = array_filter($publicationFormats, function($format) {
             return $format->getIsAvailable() && 
             $format->getIsApproved();
         });
-        $this->appendTextMiningCollectionNodes($doc, $doiDataNode, $submission, $validFormats, true);    
+        $this->appendAsCrawledCollectionNodes($doc, $doiDataNode, $submission, $validFormats, true, null);
+        $this->appendTextMiningCollectionNodes($doc, $doiDataNode, $submission, $validFormats, true, null);    
 		$bookMetadataNode->appendChild($doiDataNode);
 
 		return $bookMetadataNode;
 	}
 
     /**
+     * Append the collection node 'collection property="crawler-based"' to the doi data node.
+     *
+     * This method generates a <collection> element with property="crawler-based" for the provided 
+     * publication formats of a submission. It includes only files that are marked as proof and viewable, 
+     * and filters further to only include PDF files (required for crawler compatibility, e.g. iParadigms).
+     *
+     * The resulting node is appended to the given <doi_data> node as part of the Crossref XML export.
+     *
+     * @param \DOMDocument $doc The XML document being generated.
+     * @param \DOMElement $doiDataNode The parent <doi_data> element to which the collection will be appended.
+     * @param \APP\submission\Submission $submission The submission object the files belong to.
+     * @param array $filteredFormats Array of \PKP\publicationFormats\PublicationFormat objects to process.
+     * @param bool $isMonograph Whether the files being processed belong to a monograph (true) or a chapter (false).
+     */
+    public function appendAsCrawledCollectionNodes($doc, $doiDataNode, $submission, $filteredFormats, $onlyMonographFiles = true, $chapterId = null)
+    {
+        try {
+            $deployment = $this->getDeployment();
+            $context = $deployment->getContext();
+            $request = Application::get()->getRequest();
+            $dispatcher = $this->_getDispatcher($request);
+
+            $submissionId = $submission->getId();
+
+            // Get all visible proof files
+            $submissionFiles = Repo::submissionFile()
+                ->getCollector()
+                ->filterBySubmissionIds([$submission->getId()])
+                ->filterByFileStages([SubmissionFile::SUBMISSION_FILE_PROOF])
+                ->getMany()
+                ->filter(fn($file) => $file->getViewable());                
+
+            $monographFileGenreIds = [3]; // ID for book manuscript
+            $chapterFileGenreIds = [4]; // ID for chapter manuscript
+
+            $filteredFiles = $submissionFiles->filter(function ($file) use ($onlyMonographFiles, $monographFileGenreIds, $chapterFileGenreIds, $chapterId) {
+                $genreId = $file->getData('genreId');
+                if (!$file->getData('viewable')) {
+                    return false;
+                }
+                if ($onlyMonographFiles) {
+                    return in_array($genreId, $monographFileGenreIds);
+                }
+                return in_array($genreId, $chapterFileGenreIds) &&
+                       $file->getData('chapterId') == $chapterId;
+            });  
+
+            $filesByFormatId = [];
+            foreach ($filteredFiles as $file) {
+                $formatId = $file->getData('assocId');
+                if (!isset($filesByFormatId[$formatId])) {
+                    $filesByFormatId[$formatId] = [];
+                }
+                $filesByFormatId[$formatId][] = $file;
+            }
+
+            $crawlerCollectionNode = null;
+
+            foreach ($filteredFormats as $format) {
+                $formatId = $format->getId();
+
+                if (empty($filesByFormatId[$formatId])) {
+                    continue;
+                }
+
+                foreach ($filesByFormatId[$formatId] as $file) {
+                    $mimeType = $file->getData('mimetype');
+
+                    if ($mimeType !== 'application/pdf') {
+                        continue;
+                    }
+
+                    if ($crawlerCollectionNode === null) {
+                        $crawlerCollectionNode = $doc->createElementNS($deployment->getNamespace(), 'collection');
+                        $crawlerCollectionNode->setAttribute('property', 'crawler-based');
+                    }                    
+
+                    $url = $dispatcher->url(
+                        $request,
+                        PKPApplication::ROUTE_PAGE,
+                        $context->getPath(),
+                        'catalog',
+                        'view',
+                        [$submissionId, $formatId, $file->getId()],
+                        null,
+                        null,
+                        true
+                    );
+
+                    $itemNode = $doc->createElementNS($deployment->getNamespace(), 'item');
+                    $itemNode->setAttribute('crawler', 'iParadigms');
+
+                    $resourceNode = $doc->createElementNS($deployment->getNamespace(), 'resource', $url);
+                    $itemNode->appendChild($resourceNode);
+                    $crawlerCollectionNode->appendChild($itemNode);
+                }
+            }
+
+            if ($crawlerCollectionNode !== null) {
+                $doiDataNode->appendChild($crawlerCollectionNode);
+            }
+
+        } catch (Throwable $e) {
+            error_log('Error in appendAsCrawledCollectionNodes: ' . $e->getMessage());
+            error_log($e->getTraceAsString());
+        }
+    }       
+
+    /**
      * Append the collection node 'collection property="text-mining"' to the doi data node.
      *
-     * @param \DOMDocument $doc
-     * @param \DOMElement $doiDataNode
-     * @param \APP\submission\Submission $submission
-     * @param array $publicationFormats Array of \PKP\publicationFormats\PublicationFormat objects
+     * This method generates a <collection> element with property="text-mining" for the provided 
+     * publication formats of a submission. It includes all proof files marked as viewable, 
+     * optionally filtering them based on whether they belong to a monograph or a chapter.
+     *
+     * Each file is added as an <item> with a <resource> URL pointing to its download location. 
+     * If the file includes a MIME type, it will be added as an attribute to the <resource> element.
+     *
+     * The resulting node is appended to the given <doi_data> node as part of the Crossref XML export.
+     *
+     * @param \DOMDocument $doc The XML document being generated.
+     * @param \DOMElement $doiDataNode The parent <doi_data> element to which the collection will be appended.
+     * @param \APP\submission\Submission $submission The submission object the files belong to.
+     * @param array $validFormats Array of \PKP\publicationFormats\PublicationFormat objects to process.
+     * @param bool $onlyMonographFiles Whether to include only monograph files (true) or chapter files (false).
      */
-    public function appendTextMiningCollectionNodes($doc, $doiDataNode, $submission, $validFormats, $onlyMonographFiles = true)
+    public function appendTextMiningCollectionNodes($doc, $doiDataNode, $submission, $validFormats, $onlyMonographFiles = true, $chapterId = null)
     {
         try {
             $deployment = $this->getDeployment();
@@ -319,13 +440,17 @@ class CrossrefXmlFilter extends NativeExportFilter
             $monographFileGenreIds = [3]; // ID for book manuscript
             $chapterFileGenreIds = [4]; // ID for chapter manuscript
                 
-            $filteredFiles = $submissionFiles->filter(function ($file) use ($onlyMonographFiles, $monographFileGenreIds, $chapterFileGenreIds) {
+            $filteredFiles = $submissionFiles->filter(function ($file) use ($onlyMonographFiles, $monographFileGenreIds, $chapterFileGenreIds, $chapterId) {
                 $genreId = $file->getData('genreId');
-                return $file->getData('viewable') === true &&
-                       ($onlyMonographFiles
-                            ? in_array($genreId, $monographFileGenreIds)
-                            : in_array($genreId, $chapterFileGenreIds));
-            });            
+                if (!$file->getData('viewable')) {
+                    return false;
+                }
+                if ($onlyMonographFiles) {
+                    return in_array($genreId, $monographFileGenreIds);
+                }
+                return in_array($genreId, $chapterFileGenreIds) &&
+                       $file->getData('chapterId') == $chapterId;
+            });                        
     
             $filesByFormatId = [];
             foreach ($filteredFiles as $file) {
@@ -336,8 +461,7 @@ class CrossrefXmlFilter extends NativeExportFilter
                 $filesByFormatId[$formatId][] = $file;
             }
     
-            $textMiningCollectionNode = $doc->createElementNS($deployment->getNamespace(), 'collection');
-            $textMiningCollectionNode->setAttribute('property', 'text-mining');
+            $textMiningCollectionNode = null;
     
             foreach ($validFormats as $format) {
                 $formatId = $format->getId();
@@ -346,6 +470,12 @@ class CrossrefXmlFilter extends NativeExportFilter
                 }
     
                 foreach ($filesByFormatId[$formatId] as $file) {
+
+                    if ($textMiningCollectionNode === null) {
+                        $textMiningCollectionNode = $doc->createElementNS($deployment->getNamespace(), 'collection');
+                        $textMiningCollectionNode->setAttribute('property', 'text-mining');
+                    }                    
+
                     $url = $dispatcher->url(
                         $request,
                         PKPApplication::ROUTE_PAGE,
@@ -369,8 +499,10 @@ class CrossrefXmlFilter extends NativeExportFilter
                     $textMiningCollectionNode->appendChild($itemNode);
                 }
             }
-    
-            $doiDataNode->appendChild($textMiningCollectionNode);
+            if ($textMiningCollectionNode !== null) {
+                $doiDataNode->appendChild($textMiningCollectionNode);
+            }
+            //$doiDataNode->appendChild($textMiningCollectionNode);
         } catch (Throwable $e) {
             error_log('Error in appendTextMiningCollectionNodes: ' . $e->getMessage());
         }
@@ -500,7 +632,8 @@ class CrossrefXmlFilter extends NativeExportFilter
             return $format->getIsAvailable() && 
             $format->getIsApproved();
         });
-        $this->appendTextMiningCollectionNodes($doc, $doiDataNode, $submission, $validFormats, false); 
+        $this->appendAsCrawledCollectionNodes($doc, $doiDataNode, $submission, $validFormats, false, $chapter->getId());
+        $this->appendTextMiningCollectionNodes($doc, $doiDataNode, $submission, $validFormats, false, $chapter->getId()); 
 		$contentItemNode->appendChild($doiDataNode);
 
 		return $contentItemNode;

--- a/filter/CrossrefXmlFilter.php
+++ b/filter/CrossrefXmlFilter.php
@@ -30,6 +30,7 @@ use PKP\core\PKPString;
 use PKP\filter\FilterGroup;
 use PKP\i18n\LocaleConversion;
 use PKP\plugins\importexport\native\filter\NativeExportFilter;
+use APP\file\SubmissionFile;
 
 class CrossrefXmlFilter extends NativeExportFilter
 {
@@ -280,10 +281,76 @@ class CrossrefXmlFilter extends NativeExportFilter
 		$doiDataNode = $doc->createElementNS($deployment->getNamespace(), "doi_data");
 		$doiDataNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'doi', $this->xmlEscape($doi)));
 		$doiDataNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'resource', $this->xmlEscape($url)));
+        // Publication formats
+        $validFormats = array_filter($publicationFormats, function($format) {
+            return $format->getIsAvailable() && 
+            $format->getIsApproved();
+        });
+        error_log(print_r($validFormats, true));
+        $this->appendTextMiningCollectionNodes($doc, $doiDataNode, $submission, $validFormats);
 		$bookMetadataNode->appendChild($doiDataNode);
 
 		return $bookMetadataNode;
 	}
+
+    /**
+     * Append the collection node 'collection property="text-mining"' to the doi data node.
+     *
+     * @param \DOMDocument $doc
+     * @param \DOMElement $doiDataNode
+     * @param \APP\submission\Submission $submission
+     * @param array $publicationFormats Array of \PKP\publicationFormats\PublicationFormat objects
+     */
+    public function appendTextMiningCollectionNodes($doc, $doiDataNode, $submission, $publicationFormats)
+    {
+        $deployment = $this->getDeployment();
+        $context = $deployment->getContext();
+        $request = Application::get()->getRequest();
+        $dispatcher = $this->_getDispatcher($request);
+    
+        $textMiningCollectionNode = $doc->createElementNS($deployment->getNamespace(), 'collection');
+        $textMiningCollectionNode->setAttribute('property', 'text-mining');
+    
+        // Obtener todos los archivos de prueba asociados a la monografía
+        $submissionFiles = Services::get('submissionFile')->getMany([
+            'submissionIds' => [$submission->getId()],
+            'fileStages' => [SubmissionFile::SUBMISSION_FILE_PROOF],
+        ]);
+    
+        foreach ($publicationFormats as $publicationFormat) {
+            $formatId = $publicationFormat->getId();
+    
+            // Filtrar archivos relacionados con este formato
+            $formatFiles = array_filter($submissionFiles, function($file) use ($formatId) {
+                return $file->getAssocType() === ASSOC_TYPE_PUBLICATION_FORMAT &&
+                       $file->getAssocId() === $formatId;
+            });
+    
+            foreach ($formatFiles as $file) {
+                // Construir URL personalizada: /catalog/view/{submission_id}/{pub_format_id}/{file_id}
+                $resourceUrl = $dispatcher->url(
+                    $request,
+                    PKPApplication::ROUTE_PAGE,
+                    $context->getPath(),
+                    'catalog',
+                    'view',
+                    [$submission->getId(), $formatId, $file->getFileId()],
+                    null,
+                    null,
+                    true
+                );
+    
+                $itemNode = $doc->createElementNS($deployment->getNamespace(), 'item');
+                $resourceNode = $doc->createElementNS($deployment->getNamespace(), 'resource', $resourceUrl);
+                $resourceNode->setAttribute('mime_type', $file->getData('mimetype'));
+    
+                $itemNode->appendChild($resourceNode);
+                $textMiningCollectionNode->appendChild($itemNode);
+            }
+        }
+    
+        $doiDataNode->appendChild($textMiningCollectionNode);
+    }    
 
     /**
      * Create and return the Crossref book series metadata node 'series_metadata'.


### PR DESCRIPTION
This PR adds support for generating <collection> nodes in the Crossref deposit XML for both monographs and chapters, in compliance with Crossref schema 4.3.7.

Two types of collections are now included:

* collection property="text-mining": Includes all viewable proof files, regardless of file type.

* collection property="crawler-based": Includes only PDF files, as required by iParadigms crawler.

Each collection is created only when applicable (i.e., when valid files exist). For chapters, filtering is done based on chapterId to ensure that only files related to the current chapter are included.

These changes help enhance metadata coverage and support services such as text/data mining and plagiarism detection through proper collection linkage.

Is pending to refactor code in order to supress duplicate methods/functions